### PR TITLE
Upgrade: Use latest version of Draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@shopify/draggable": "1.0.0-beta.3",
+    "@shopify/draggable": "^1.0.0-beta.4",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,9 +85,9 @@
   dependencies:
     "@glimmer/util" "^0.25.4"
 
-"@shopify/draggable@1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.3.tgz#b207effa1b85d31efbe1c3d8d40d785a2cb100c4"
+"@shopify/draggable@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@shopify/draggable/-/draggable-1.0.0-beta.4.tgz#c8982960c095477704de58f0a0806fa93fe6efa0"
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
Bumps up to the latest beta release, and adds `^` to account for future releases.